### PR TITLE
Add FlutterFramework SwiftPM dep

### DIFF
--- a/native_image_cropper_ios/ios/native_image_cropper_ios/Package.swift
+++ b/native_image_cropper_ios/ios/native_image_cropper_ios/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "native-image-cropper-ios", targets: ["native_image_cropper_ios"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "native_image_cropper_ios",
-            dependencies: []
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
         )
     ]
 )

--- a/native_image_cropper_macos/macos/native_image_cropper_macos/Package.swift
+++ b/native_image_cropper_macos/macos/native_image_cropper_macos/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "native-image-cropper-macos", targets: ["native_image_cropper_macos"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "native_image_cropper_macos",
-            dependencies: []
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
         )
     ]
 )


### PR DESCRIPTION
<!--
  Thank you for contributing to native_image_cropper!

  Please provide a clear and concise title for your pull request, and describe the changes you’ve made in detail below.

  Before submitting, please review our contribution guidelines:
  https://github.com/cosee/native_image_cropper/blob/main/CONTRIBUTING.md
-->

### DESCRIPTION

- There's a new section into the [migration guide](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin). Now, adding `FlutterFramework` dependency is required to avoid a new warning.
